### PR TITLE
policies: add Conflict of Interest policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,8 @@ The "Stiching NixOS Foundation" is a registered non-profit organisation at the C
 * Armijn Hemel - Secretary
 * Rob Vermaas - Treasurer
 
+## Policies
+
+The NixOS Foundation board members adhere to the following policies:
+
+* [Conflict of Interest](policies/conflict_of_interest.md)

--- a/policies/conflict_of_interest.md
+++ b/policies/conflict_of_interest.md
@@ -1,0 +1,20 @@
+# Conflict of Interest Rule
+
+Purpose: This conflict of interest rule aims to ensure that the foundation leading the NixOS project operates in an impartial and transparent manner, avoiding any conflicts of interest that may arise due to members' involvement in companies that benefit from the project.
+
+Scope: This rule applies to all members of the NixOS Foundation.
+
+Definition: For the purposes of this rule, a conflict of interest is any situation in which a member's personal, financial, or other interests conflict, or appear to conflict, with the interests of the foundation leading the NixOS project.
+
+Guidelines:
+
+1. Disclosure of Conflicts of Interest: All members of the foundation leading the open source project must disclose any conflicts of interest to the foundation's board of directors and the project's governance body as soon as they become aware of them.
+
+2. Recusal: Members with a conflict of interest must recuse themselves from any decision-making process or vote related to the project where the conflict of interest exists. The recusal should be documented in the project's meeting minutes.
+
+3. Transparency: The foundation leading the open source project must disclose any conflicts of interest to the project's community. Members should avoid giving the impression that their personal interests influence the foundation's decision-making process.
+
+4. Mitigation: Members with a conflict of interest may participate in discussions related to the project but must clearly disclose their conflicts of interest and refrain from advocating for their personal interests.
+
+5. Consequences: Failure to comply with this conflict of interest rule may result in disciplinary action, including but not limited to removal from the foundation's board of directors or governance body.
+


### PR DESCRIPTION
This is something I had on my mind lately.

I want to avoid future conflicts of interest seeping into the foundation's organizational structure as this is distracting and damaging to both our group and the community.
