### PR TITLE
feat: add project lead team

### DIFF
--- a/event-project-lead.md
+++ b/event-project-lead.md
@@ -1,0 +1,38 @@
+In recognition of the paramount importance of formal events within the Nix ecosystem, associated with the NixOS Foundation, we present this proposal for the establishment of a structured organizational framework. This framework seeks to provide a cohesive structure for the planning and execution of all formal events, including but not limited to NixCon, thereby ensuring their continued success and sustained growth.
+
+# Establishment of the "Bootstrap Project Lead Team"
+
+The cornerstone of this proposal lies in the creation of a "Bootstrap Project Lead Team" in charge of every formal event within the Nix ecosystem. This team shall comprise dedicated individuals from the community, possessing a profound commitment to the Nix ethos and a proven track record in event management. 
+
+The Bootstrap Project Lead Team shall assume responsibility for the comprehensive organization and execution of the event, including the management of formal event assets and brands. 
+
+It's crucial to clarify that the Bootstrap Project Lead Team is a separate entity from the local event organizers that may or may not exist for a given event. However, in all cases, they must collaborate with the Project Lead Team on event organization matters. 
+
+The responsibilities of the Bootstrap Project Lead Team shall encompass:
+
+
+- **Early planning** and strategizing for the event, including ensuring **event consistency** to maintain integrity, reputation, and impact.
+- **Venue selection**, taking into account factors such as accessibility, cost, and capacity.
+- **Budget planning**, fundraising, and **sponsorship acquisition** in collaboration with the NixOS Foundation.
+- **Speaker outreach** and curation of a diverse and engaging lineup.
+- **Community engagement** to foster participation and contributions.
+- **Documentation** of the organizational process for future reference.
+- **Establishment** of a clear timeline with milestones for all organizational tasks.
+
+The provisional members of the Bootstrap Project Lead Team are as follows:
+
+- @raitobezarius
+- @hexchen
+- @Janik
+- @0x4A6F
+- @JulienMalka (new member since the announce)
+
+Additionally, oversight for the Bootstrap Project Lead Team will be provided by Ron Efroni, who represents the NixOS Foundation Board.
+
+# Formation of the Final Team
+
+In tandem with the activities of the Bootstrap Project Lead Team, efforts shall be directed towards the formation of the Final Team, which shall assume responsibility for the comprehensive organization and execution of the event. The Final Team shall be constituted through a transparent and inclusive process, guided by community input and merit-based selection criteria.
+
+To this end, community members interested in joining the Final Team are encouraged to express their interest and qualifications. The selection process shall prioritize diversity, expertise, and a demonstrated commitment to the Nix ecosystem.
+
+Until such time as the Final Team is duly constituted, the Bootstrap Project Lead Team shall remain active to ensure continuity in event organization and facilitate a smooth transition of responsibilities.


### PR DESCRIPTION
As this is a team that owns assets which were in Foundation's hands in the past, it makes sense to attach a document in the Foundation repository for it.

As per @zimbatm ask of a formal document, contains the `Sign-off-by` of all the current bootstrap PL team.