### PR TITLE
Zulip for governance discussions

### DIFF
--- a/governance/zulip.md
+++ b/governance/zulip.md
@@ -1,0 +1,25 @@
+- Dedicate https://nixpkgs.zulipchat.com/ to discuss community governance _exclusively_
+- The [permissions](https://docs.zulip.com/help/roles-and-permissions) are as follows
+  - Organization owners: Board members
+  - Organization admins: Board observers
+  - Moderators: Moderation team, board observers and @infinisil
+    - In addition to the CoC, they will ensure it's only used for governance discussions
+  - The conversations are publicly readable to anyone, but joining the conversation requires a one-time approval (see below)
+
+- To join the discussion on Zulip, users have three options:
+  - If you have contributed to the Nix ecosystem, post a message containing a link to your contribution. The exact kind of contribution does not matter, as long as it is _before 2024-05-01_.
+  - If you have made a substantial and constructive contribution to setting up a successful community-based governance structure, post a message with a link to your contribution
+  - If you do not qualify for the above, but still believe you could contribute, reach out to the Zulip moderators in private on Discourse
+
+- To post a message:
+  - If your contribution was on GitHub, post it to {dedicated foundation Github issue}
+  - If it was not on Github, post it to {Discourse thread}
+  - The message might look like:
+    Contribution: [some-link]
+    Email: [some-email]
+  - As soon as a Zulip moderator has confirmed your contribution, they'll send an invite
+    - They'll check that the contribution is from the same user and that it happened before 2024-05-01
+
+- Should banned people be allowed to join?
+  - Yes, but they get one shot to be in the conversation, with extreme prejudice
+  - If they blow it, it's a permaban (for all community platforms, not just Zulip)


### PR DESCRIPTION
To get started in a productive way with https://discourse.nixos.org/t/nixos-foundation-board-giving-power-to-the-community/44552, a couple community members [worked together](https://matrix.to/#/!VyoUhyWvlhSpFWWxHL:matrix.org/$qOJ6c8CdqzcIrvzqO_WeUv5L1b0zMeCLBAdEaNmv7j4?via=nixos.org&via=matrix.org&via=fairydust.space) on this proposal to use Zulip for governance discussion and how exactly. We'd like the foundation board to decide over it.

Why Zulip? Mainly because we started discussing stuff on Matrix until it became too messy 5 minutes in (and Matrix threads don't work well). Zulip doesn't have that issue, let's use it from the start for governance discussions.

By merging this PR I'm assuming the responsibility to make this proposal reality, there is no further action needed by the board.

Signed by:
- @infinisil
- @raitobezarius
- @Janik-Haag 
- @mweinelt
- @samrose
- @patka-123
- @endocrimes
- @ashkitten
- @joepie91
- @djacu
- @ryantm