### PR TITLE
Add CoC and deescalation docs for Zulip

### DIFF
--- a/governance/zulip/coc.md
+++ b/governance/zulip/coc.md
@@ -22,7 +22,7 @@ We understand that not everybody has done this type of work before, or has the s
 
 Everyone is responsible for preventing and taking action against abusive behavior. We speak up when we see others engaging in negative behavior and bring in moderation as necessary to resolve problems.
 
-There are many types of abusive behavior, and it’s impossible to define them, but some are defined below to help level set. Ultimately, the Zulip moderation team decides what is acceptable and unacceptable conduct.
+There are many types of abusive behavior, and it’s impossible to list them exhaustively, but some are defined below to help level set. Ultimately, the Zulip moderation team decides what is acceptable and unacceptable conduct.
 
 ### Derogatory Language
 

--- a/governance/zulip/coc.md
+++ b/governance/zulip/coc.md
@@ -1,0 +1,69 @@
+# Nix Governance Discussion Conduct
+
+Open Source doesn't work without the people who make the software happen. The governance project is putting people first and doing its best to recognize, appreciate, and respect the diversity of our global contributor base. We welcome contributions from all qualified (through contribution or prior experience) people who want to contribute in a healthy and constructive manner.
+
+These guidelines aim to support bootstrapping our governance structure, and as such *all* who can, should feel safe to participate regardless of background, family status, gender, gender identity and expression, marital status, sex, sexual orientation, plurality, native language, age, race/ethnicity, nationality, socioeconomic status, geographic location, education, or other aspects of diversity.
+
+### We are respectful
+
+We value each others ideas and viewpoints. We are open to different possibilities and being wrong. We are aware of our *impact* and how interactions will affect others. We are direct, constructive, and positive. We take responsibility for our impact and our mistakes - if someone says that they have been harmed by our words or actions, we *stop*, *listen*, and then *apologize sincerely* and *change behavior.*
+
+### We are inclusive
+
+As an open source project we are building on the work of, and building for, other people. In governance we are building for the builders and for the users. We need to be mindful of the needs of those who will be impacted by our work, demonstrating patience, kindness, and understanding. We think about the impact of our decisions on others and ensure to bring in diverse perspectives and make inclusive choices. We understand that the emphasis is on ensuring that even minoritised groups feel safe in our spaces.
+
+### We ask for help when we need it
+
+When we need clarity, we ask questions simply and directly. We understand that contributors may not have the time to answer every question, and before asking we review existing documentation to see if we can find the answer.
+
+We understand that not everybody has done this type of work before, or has the same knowledge and experience. We aim to document our work so that all may benefit from the experience that we do have.
+
+## We do not tolerate abusive behavior
+
+Everyone is responsible for preventing and taking action against abusive behavior. We speak up when we see others engaging in negative behavior and bring in moderation as necessary to resolve problems.
+
+There are many types of abusive behavior, and it’s impossible to define them, but some are defined below to help level set. Ultimately, the Zulip moderation team decides what is acceptable and unacceptable conduct.
+
+### Derogatory Language
+
+Hurtful or harmful language related to:
+
+- Background
+- Family status
+- Gender
+- Gender identity or expression
+- Plurality
+- Marital status
+- Sex
+- Sexual orientation
+- Native language
+- Age
+- Ability
+- Race and/or ethnicity
+- National origin
+- Socioeconomic status
+- Religion
+- Geographic location
+- Other attributes
+
+is not acceptable. This includes deliberately referring to someone by a gender that they do not identify with, and/or questioning the legitimacy of an individual’s gender identity. If you’re unsure if a word is derogatory, don’t use it. This also includes repeated subtle and/or indirect discrimination; when asked to stop, stop the behavior in question.
+
+### Disruptive Behavior
+
+Disrupting the proceedings will not be tolerated. This includes, but is not limited to:
+
+- Bad faith invitations to engage in debate, regardless of the pretense of civility.
+- Attempting to use the specific wording of rules documents without referencing or understanding their spirit.
+- Influencing outside communities to cause hostility towards participants.
+- Reducing a discussion to one of a country’s political system. We are a global group with different perspectives. We are not more or less valuable based on the system we grew up with.
+
+We will treat influencing or leading such activities the same way we treat the activities themselves, and thus the same consequences apply.
+
+### Violence and Threats of Violence
+
+Violence and threats of violence are not acceptable - online or offline. This includes incitement of violence toward any individual, including encouraging a person to commit self-harm. This also includes posting or threatening to post other people’s personally identifying information (“doxxing”) online.
+
+### Personal Attacks
+
+Conflicts will inevitably arise, but frustration should never turn into a personal attack. It is not okay to insult, demean or belittle others. Attacking someone for their opinions, beliefs and ideas is not 
+acceptable. It is important to speak directly when we disagree and when we think we need to improve, but such discussions must be conducted respectfully and professionally, remaining focused on the issue at hand.

--- a/governance/zulip/deescalation.md
+++ b/governance/zulip/deescalation.md
@@ -1,0 +1,27 @@
+# How to de-escalate situations
+
+Governance is a complicated topic that often creates conflicts; some of them small, some of them not so small. Moderators are tasked with ensuring that the governance Zulip remains a constructive space for people to talk these things out, but there is a lot that you can do yourself to keep the discussion constructive; or even as a third party intervening in someone else's escalating discussion.
+
+This guide describes some techniques that can be used to prevent and de-escalate conflicts, and help to keep the governance discussion productive for everyone involved. We encourage you to use them!
+
+This guide is based in part on https://libera.chat/guides/catalyst, although several changes and additions have been made to better fit our specific situation.
+
+## Assume good faith
+
+The people who participate in these governance conversations, are most likely here because they want the project governance to be improved, just like you. Try to assume that the other person is doing what they're doing in good faith. There are only very few people who genuinely seek to cause disruption, and if that is the case, it becomes a task for moderators to handle.
+
+## Listen and ask
+
+A lot of conflicts can be both prevented and de-escalated by simply asking more questions and listening more, instead of speaking. In general, prefer to ask people *why* they feel a certain way if that is unclear, rather than assuming their intentions - this will provide more space for concerns that would otherwise go overlooked, and avoid creating conflicts due to wrong assumptions.
+
+Even when a conflict has already arisen, asking questions can still be effective to de-escalate; asking people why they are doing something will encourage them to reflect on their behaviour, and this can often lead to self-moderation. Most people do not want to be viewed as "the bad guy".
+
+Likewise, in a conflict, prefer asking for someone's input rather than admonishing their behaviour; this centers the conversation on them and their thoughts, instead of on yourself. Even if you disagree, you are more likely to gain a useful insight this way, and calming down the situation helps everyone involved.
+
+If you need to concretely ask someone to change their behaviour, prefer asking them as a "can you do this?" question, rather than outright demanding it - they will likely be more receptive to your request, and if there is a reason why they cannot, you can look for a solution to that together.
+
+## Compromises and reconciliation
+
+Many disagreements are not really fundamental: often there is just a miscommunication, or some mismatch in assumptions. When it seems like you cannot find agreement, try narrowing down exactly where the disagreement comes from, what the most precise difference between your views is. Often, this will inspire new solutions that work for everyone involved, and that reconcile your differences - eliminating the disagreement entirely.
+
+If all else fails, it is often better to find a compromise that everyone can be reasonably happy with, than to leave one side of the conflict entirely unsatisfied. This should be a last resort; too many compromises can easily stack together into a sense of nothing ever being decided, or nothing being changeable. You should always prefer finding reconciliation instead, as described above. True compromise should be very rarely needed.


### PR DESCRIPTION
We [worked out](https://matrix.to/#/!VyoUhyWvlhSpFWWxHL:matrix.org/$aCUuHjjb3ZXybuOXi-1fZ1AmOoWymyD7GTQzFoM6MsE?via=nixos.org&via=matrix.org&via=matrix.dapp.org.uk) reasonable CoC  (primary author @endocrimes) and deescalation docs (primary author @joepie91) together for the Zulip instance. Let's get this merged so we can link to it.

Feel free to add your signature with :+1:!

Note that we're discussing this live in the [Zulip setup coordination](https://matrix.to/#/#platform-governance:nixos.org) Matrix room.